### PR TITLE
Use a value from 0 to 100 to set volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ console.log('after',  alsaVolume.getVolume('default', 'Line'));
 
 Use `alsamixer` to identify mixer names. Usually `Master`, `PCM`, etc.
 
-## To-Do list
-
-- Implement `snd_mixer_selem_get_playback_volume_range` instead of trial, error and hardcoding. See [1](https://stackoverflow.com/questions/56675099/how-to-change-volume-of-speaker-using-alsa-library), [2](https://www.alsa-project.org/alsa-doc/alsa-lib/group___simple_mixer.html#ga09557e90c11fbd37aeed30938338698b) 
 
 ## Credits
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alsa-volume",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Functions to get/set volume for ALSA devices on Linux",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I've implemented the missing call to `snd_mixer_selem_get_playback_volume_range()`, using a volume range from 0 to 100. It could have also been a float, but I think this way is more intuitive. In any case, I hope it helps as reference for other implementations.

I'm also working on mute status + toggling mute on my fork, but I've modified it for a specific case so it may not be ideal to merge as it is, at least for now.