### PR TITLE
Slight adjustment to error formatting

### DIFF
--- a/alsa-getmute.cc
+++ b/alsa-getmute.cc
@@ -16,9 +16,9 @@ const snd_mixer_selem_channel_id_t CHANNEL = SND_MIXER_SCHN_FRONT_LEFT;
 static void error_close_exit(char *errmsg, int err, snd_mixer_t *h_mixer)
 {
 	if (err == 0)
-		fprintf(stderr, errmsg);
+        fprintf(stderr, "%s", errmsg);
 	else
-		fprintf(stderr, errmsg, snd_strerror(err));
+        fprintf(stderr, "%s %s\n", errmsg, snd_strerror(err));
 	if (h_mixer != NULL)
 		snd_mixer_close(h_mixer);
 	exit(EXIT_FAILURE);

--- a/alsa-getvolume.cc
+++ b/alsa-getvolume.cc
@@ -17,9 +17,9 @@ const snd_mixer_selem_channel_id_t CHANNEL = SND_MIXER_SCHN_FRONT_LEFT;
 static void error_close_exit(char *errmsg, int err, snd_mixer_t *h_mixer)
 {
 	if (err == 0)
-		fprintf(stderr, errmsg);
+        fprintf(stderr, "%s", errmsg);
 	else
-		fprintf(stderr, errmsg, snd_strerror(err));
+        fprintf(stderr, "%s %s\n", errmsg, snd_strerror(err));
 	if (h_mixer != NULL)
 		snd_mixer_close(h_mixer);
 	exit(EXIT_FAILURE);

--- a/alsa-setmute.cc
+++ b/alsa-setmute.cc
@@ -16,9 +16,9 @@ const snd_mixer_selem_channel_id_t CHANNEL = SND_MIXER_SCHN_FRONT_LEFT;
 static void error_close_exit(char *errmsg, int err, snd_mixer_t *h_mixer)
 {
 	if (err == 0)
-		fprintf(stderr, errmsg);
+        fprintf(stderr, "%s", errmsg);
 	else
-		fprintf(stderr, errmsg, snd_strerror(err));
+        fprintf(stderr, "%s %s\n", errmsg, snd_strerror(err));
 	if (h_mixer != NULL)
 		snd_mixer_close(h_mixer);
 	exit(EXIT_FAILURE);

--- a/alsa-setvolume.cc
+++ b/alsa-setvolume.cc
@@ -16,9 +16,9 @@
 static void error_close_exit(char *errmsg, int err, snd_mixer_t *h_mixer)
 {
 	if (err == 0)
-		fprintf(stderr, errmsg);
+        fprintf(stderr, "%s", errmsg);
 	else
-		fprintf(stderr, errmsg, snd_strerror(err));
+        fprintf(stderr, "%s %s\n", errmsg, snd_strerror(err));
 	if (h_mixer != NULL)
 		snd_mixer_close(h_mixer);
 	exit(EXIT_FAILURE);


### PR DESCRIPTION
Compiling with Werror=format-security will throw an error when it finds fprintf(stderr, errmsg);

This is really trivial but it considers it a format string security vulnerability. 
The issue is that fprintf(stderr, errmsg) treats errmsg (a variable) as the format string. If that variable contains %x or %n etc., it could be exploited.

I encountered the issue when trying to run "npm install" while building an embedded linux image using Yocto (~Node 22.14)

Fix applied : 
- Change fprintf(stderr, errmsg); to fprintf(stderr, "%s", errmsg);
- Same thing for the other fprintfs a couple of lines below.
